### PR TITLE
Fixed typos, removed redundant parentheses and dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,19 +57,19 @@ let doubleTransform = FATransformOf<Int, Double> {
 
 ## Feature
 
-- Working with Nested None `Foundation.Coable` property 
+- Working with Nested None `Foundation.Codable` property 
 
 ## Known side effect 
 
-- SuperDecoable must construct from nothing `(init()`
+- SuperDecoable must construct from nothing `init()`
 - `@Keyed var id:Int` will do **O(n) calculation** on underlaying wrapper `_VARIABLE_NAME` into key `VARIABLE_NAME`. **Be ware of variable name takes too long**
 
 
 ## Known Disability
 
-- Every property in a SuperCodable should a `DecodableKey` / `EncodableKey`, otherwise the property(which should be `Cobable`) will **simply ignored** during the Codable process.
+- Every property in a SuperCodable should a `DecodableKey` / `EncodableKey`, otherwise the property(which should be `Codable`) will **simply ignored** during the Codable process.
 > Why:
->> Basically Mirror can't matating the object value during the . `init(from decoder:) throws`, since we create the object from `self.init()`
+>> Basically Mirror can't mutating the object value during the  `init(from decoder:) throws`, since we create the object from `self.init()`
 
 
 ## Other notes


### PR DESCRIPTION
> Basically Mirror can't <ins>matating</ins> the object value during the . init(from decoder:) throws, since we create the object from self.init()

我從文意猜測這邊應該是 mutating ，如果有誤再跟我說～ 

Thanks